### PR TITLE
Fixed slave -> bond issues and standardized syntax for nmcli

### DIFF
--- a/so-setup-network.sh
+++ b/so-setup-network.sh
@@ -254,35 +254,11 @@ create_bond_nmcli() {
     MTU=1500
   fi
 
-  NMCLI_VER=$(nmcli -v | sed 's/nmcli tool, version 1\.//g' | awk -F '\\.' '{print $1}')
-
-  if [[ $NMCLI_VER -lt 12 ]]
-  then # We are using an older version of nmcli
-    
-    # Create the bond interface
-    nmcli con add ifname bond0 con-name "bond0" type bond >> $SETUPLOG 2>&1
-    nmcli con mod bond0 bond.options "mode=0" >> $SETUPLOG 2>&1
-    nmcli con mod bond0 ethernet.mtu $MTU >> $SETUPLOG 2>&1
-    nmcli con mod bond0 ipv4.method "disabled" >> $SETUPLOG 2>&1
-    nmcli con mod bond0 ipv6.method "ignore" >> $SETUPLOG 2>&1
-    nmcli con mod bond0 connection.autoconnect "yes" >> $SETUPLOG 2>&1
-
-    for BNIC in ${BNICS[@]}; do
-      # Strip the quotes from the NIC names
-      BONDNIC="$(echo -e "${BNIC}" | tr -d '"')"
-      # Create the slave interface and assign it to the bond
-      nmcli con add type ethernet ifname $BONDNIC con-name "bond0-slave-$BONDNIC" master bond0 >> $SETUPLOG 2>&1
-      nmcli con mod bond0-slave-$BONDNIC ethernet.mtu $MTU >> $SETUPLOG 2>&1
-      nmcli con mod bond0-slave-$BONDNIC connection.autoconnect "yes" >> $SETUPLOG 2>&1
-      nmcli con up bond0-slave-$BONDNIC >> $SETUPLOG 2>&1
-    done
-  else
-    # Create the bond interface
-    nmcli con add type bond ifname bond0 con-name "bond0" \
-      bond.options "mode=0" \
-      802-3-ethernet.mtu $MTU \
-      ipv4.method "disabled" \
-      ipv6.method "ignore" \
+# Create the bond interface
+    nmcli con add ifname bond0 con-name "bond0" type bond mode 0 -- \
+      ipv4.method disabled \
+      ipv6.method link-local \
+      ethernet.mtu $MTU \
       connection.autoconnect "yes" \
       >> $SETUPLOG 2>&1
 
@@ -290,15 +266,13 @@ create_bond_nmcli() {
       # Strip the quotes from the NIC names
       BONDNIC="$(echo -e "${BNIC}" | tr -d '"')"
       # Create the slave interface and assign it to the bond
-      nmcli con add type ethernet ifname $BONDNIC master bond0 \
-        connection.autoconnect "yes" \
-        802-3-ethernet.mtu $MTU \
-        con-name "bond0-slave-$BONDNIC" \
-        >> $SETUPLOG 2>&1
+      nmcli con add type ethernet ifname $BONDNIC con-name "bond0-slave-$BONDNIC" master bond0 -- \
+      ethernet.mtu $MTU \
+      connection.autoconnect "yes" \
+      >> $SETUPLOG 2>&1
       # Bring the slave interface up
       nmcli con up bond0-slave-$BONDNIC >> $SETUPLOG 2>&1
     done
-  fi
 }
 
 create_bond() {


### PR DESCRIPTION
Nmcli commands should now work on any version