### PR TITLE
Logstash tweaks

### DIFF
--- a/salt/logstash/conf/conf.enabled.txt.so-eval
+++ b/salt/logstash/conf/conf.enabled.txt.so-eval
@@ -13,7 +13,7 @@
 #/usr/share/logstash/pipeline.so/0002_input_windows_json.conf
 #/usr/share/logstash/pipeline.so/0003_input_syslog.conf
 #/usr/share/logstash/pipeline.so/0005_input_suricata.conf
-#/usr/share/logstash/pipeline.dynamic/0006_input_beats.conf
+/usr/share/logstash/pipeline.dynamic/0006_input_beats.conf
 /usr/share/logstash/pipeline.so/0007_input_import.conf
 /usr/share/logstash/pipeline.dynamic/0010_input_hhbeats.conf
 #/usr/share/logstash/pipeline.so/1000_preprocess_log_elapsed.conf

--- a/salt/logstash/files/dynamic/0006_input_beats.conf
+++ b/salt/logstash/files/dynamic/0006_input_beats.conf
@@ -1,7 +1,7 @@
 input {
   beats {
     port => "5044"
-    ssl => true
+    ssl => false
     ssl_certificate_authorities => ["/usr/share/filebeat/ca.crt"]
     ssl_certificate => "/usr/share/logstash/filebeat.crt"
     ssl_key => "/usr/share/logstash/filebeat.key"


### PR DESCRIPTION
-Disable SSL for default beats input
-Enable `0006_input_beats.conf` by default for EVAL

Closes https://github.com/Security-Onion-Solutions/securityonion-saltstack/issues/88