### PR TITLE
change intial user role to superadmin

### DIFF
--- a/salt/hive/thehive/scripts/cortex_init.sh
+++ b/salt/hive/thehive/scripts/cortex_init.sh
@@ -16,7 +16,7 @@ cortex_init(){
     curl -v -k -XPOST "https://$CORTEX_IP:/cortex/api/maintenance/migrate"
 
     # Create intial Cortex user
-    curl -v -k "https://$CORTEX_IP/cortex/api/user" -H "Content-Type: application/json" -d "{\"login\" : \"$CORTEX_USER\",\"name\" : \"$CORTEX_USER\",\"roles\" : [\"read\",\"analyze\",\"orgadmin\"],\"preferences\" : \"{}\",\"password\" : \"$CORTEX_PASSWORD\", \"key\": \"$CORTEX_KEY\"}"
+    curl -v -k "https://$CORTEX_IP/cortex/api/user" -H "Content-Type: application/json" -d "{\"login\" : \"$CORTEX_USER\",\"name\" : \"$CORTEX_USER\",\"roles\" : [\"superadmin\"],\"preferences\" : \"{}\",\"password\" : \"$CORTEX_PASSWORD\", \"key\": \"$CORTEX_KEY\"}"
 
     # Enable URLScan.io Analyzer
     curl -v -k -XPOST -H "Authorization: Bearer $CORTEX_KEY" -H "Content-Type: application/json" "https://$CORTEX_IP/cortex/api/organization/analyzer/Urlscan_io_Search_0_1_0" -d '{"name":"Urlscan_io_Search_0_1_0","configuration":{"auto_extract_artifacts":false,"check_tlp":true,"max_tlp":2}}'


### PR DESCRIPTION
Change initial user role to super admin to allow for org creation.  Will likely need to adjust later after further testing to allow for superadmin/orgadmin delineation.